### PR TITLE
Nerf the Soul Collector

### DIFF
--- a/Angel Arena/configs/items/soul_collector.kv
+++ b/Angel Arena/configs/items/soul_collector.kv
@@ -124,7 +124,7 @@
 		"13"
         {
             "var_type"				"FIELD_INTEGER"
-            "decrease_heal_pct"		"50"
+            "decrease_heal_pct"		"75"
         }
         "14"
         {
@@ -134,7 +134,7 @@
         "15"
         {
             "var_type"				    "FIELD_INTEGER"
-            "slow_percent"	            "60"
+            "slow_percent"	            "50"
         }
 		
         // Damage and heal


### PR DESCRIPTION
I think that the soul collector has a very good place in the current meta of the game, and it has honestly always been great. The problem (in my opinion) is that it is capable of decreasing the value of someones networth based on the fact that it stops all current regeneration, and on top of this it also slows for a huge amount.

This nerf would target the healing reduction primarily, but also slightly touch the slow amount to make it feel a bit more balanced without impacting the game too much.
 
Specifically for the healing reduction, I've decided to decrease it to 75%, because if you're playing as a tank hero it's capable of turning your high networth spent on tanky regen items into basically nothing. On top of this, it's also a very powerful nuke item, and when cast on enemies in their fountain you prevent the fountain from actually protecting them, and I still feel like that should never be the case. 

Decreasing it from 100% to 75% is justified, in my opinion, because the 25% will still let you keep some of that regen, while also making it possible to kill you — it would just take a second or two longer.